### PR TITLE
Add ESP32 ESP-NOW time sync example

### DIFF
--- a/sync_examples/README.md
+++ b/sync_examples/README.md
@@ -1,0 +1,16 @@
+# ESP32 Timestamp Synchronization Examples
+
+This folder contains simple ESP-IDF examples that demonstrate how two ESP32 modules can
+exchange timestamps using ESP-NOW and apply an offset to correct their local clock.
+
+- `sync_master.c` – periodically broadcasts the current time in microseconds.
+- `sync_slave.c`  – receives the master's timestamp, computes the difference
+  between the received value and its local `esp_timer_get_time()` and stores
+  it as an offset. The function `get_synced_time()` returns the corrected time.
+
+These examples assume that both devices are already configured with a common
+crystal source or hardware clock. They show how to perform a simple software
+correction for any remaining skew.
+
+To build either example, replace the contents of `main/main.cc` with the desired
+file or create a new project using the provided source code.

--- a/sync_examples/sync_master.c
+++ b/sync_examples/sync_master.c
@@ -1,0 +1,48 @@
+#include "esp_wifi.h"
+#include "esp_now.h"
+#include "esp_log.h"
+#include "esp_timer.h"
+#include <string.h>
+
+static const char *TAG = "SYNC_MASTER";
+static uint8_t peer_mac[ESP_NOW_ETH_ALEN] = {0xff,0xff,0xff,0xff,0xff,0xff};
+
+typedef struct {
+    uint32_t seq;
+    int64_t  timestamp_us;
+} sync_packet_t;
+
+static uint32_t seq = 0;
+
+static void send_sync_packet(void* arg){
+    sync_packet_t pkt;
+    pkt.seq = seq++;
+    pkt.timestamp_us = esp_timer_get_time();
+    esp_now_send(peer_mac, (uint8_t*)&pkt, sizeof(pkt));
+}
+
+void app_main(void){
+    esp_netif_init();
+    esp_event_loop_create_default();
+    wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
+    esp_wifi_init(&cfg);
+    esp_wifi_set_mode(WIFI_MODE_STA);
+    esp_wifi_start();
+
+    esp_now_init();
+    esp_now_peer_info_t peer = {0};
+    memcpy(peer.peer_addr, peer_mac, ESP_NOW_ETH_ALEN);
+    peer.channel = 0;
+    peer.ifidx = ESP_IF_WIFI_STA;
+    peer.encrypt = false;
+    esp_now_add_peer(&peer);
+
+    const esp_timer_create_args_t periodic_timer_args = {
+            .callback = &send_sync_packet,
+            .name = "sync_timer"};
+    esp_timer_handle_t periodic_timer;
+    esp_timer_create(&periodic_timer_args, &periodic_timer);
+    esp_timer_start_periodic(periodic_timer, 1000000); // send every second
+
+    ESP_LOGI(TAG, "Sync master started");
+}

--- a/sync_examples/sync_slave.c
+++ b/sync_examples/sync_slave.c
@@ -1,0 +1,44 @@
+#include "esp_wifi.h"
+#include "esp_now.h"
+#include "esp_log.h"
+#include "esp_timer.h"
+#include <string.h>
+
+static const char *TAG = "SYNC_SLAVE";
+static int64_t time_offset = 0;
+
+typedef struct {
+    uint32_t seq;
+    int64_t  timestamp_us;
+} sync_packet_t;
+
+static void recv_cb(const uint8_t *mac, const uint8_t *data, int len){
+    if(len != sizeof(sync_packet_t)) return;
+    sync_packet_t pkt;
+    memcpy(&pkt, data, sizeof(pkt));
+    int64_t local_time = esp_timer_get_time();
+    time_offset = pkt.timestamp_us - local_time;
+    ESP_LOGI(TAG, "Received seq %u, offset=%lld us", pkt.seq, (long long)time_offset);
+}
+
+int64_t get_synced_time(){
+    return esp_timer_get_time() + time_offset;
+}
+
+void app_main(void){
+    esp_netif_init();
+    esp_event_loop_create_default();
+    wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
+    esp_wifi_init(&cfg);
+    esp_wifi_set_mode(WIFI_MODE_STA);
+    esp_wifi_start();
+
+    esp_now_init();
+    esp_now_register_recv_cb(recv_cb);
+
+    ESP_LOGI(TAG, "Sync slave started");
+    while(true){
+        ESP_LOGI(TAG, "Synced time %lld", (long long)get_synced_time());
+        vTaskDelay(pdMS_TO_TICKS(1000));
+    }
+}


### PR DESCRIPTION
## Summary
- add `sync_examples` with ESP-NOW master/slave code
- include README that explains how to use the examples

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68405c3c9388832b93db3aad7f2b37ea