### PR TITLE
Add ESP32-CSI-Tool components

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,20 @@ idf.py -p "$ESPPORT" flash monitor
 ## Changing the WiFi channel
 
 The default channel is configured through the `WIFI_CHANNEL` value. You can change it either in `main/main.cc` or by modifying the `CONFIG_WIFI_CHANNEL` setting in `sdkconfig`.
+
+## ESP32-CSI-Tool components
+
+This project reuses helper components from the [ESP32-CSI-Tool](https://github.com/StevenMHernandez/ESP32-CSI-Tool) repository. The required header files are included in the `_components` directory. If you need to update or re-fetch these files, clone the CSI tool repository and copy its `_components` folder into the root of this project:
+
+```bash
+git clone https://github.com/StevenMHernandez/ESP32-CSI-Tool.git
+cp -r ESP32-CSI-Tool/_components .
+```
+
+Alternatively you can track the dependency using a git submodule:
+
+```bash
+git submodule add https://github.com/StevenMHernandez/ESP32-CSI-Tool.git external/ESP32-CSI-Tool
+```
+
+The headers provide the implementations for `nvs_component`, `sd_component`, `csi_component`, `time_component`, and `input_component` used by `main/main.cc`.

--- a/_components/README.md
+++ b/_components/README.md
@@ -1,0 +1,3 @@
+## Global Components for each ESP32 Sub-project
+
+The files in this directory allow us to create reusable components for use in all of the esp-idf sub-projects.

--- a/_components/csi_component.h
+++ b/_components/csi_component.h
@@ -1,0 +1,114 @@
+#ifndef ESP32_CSI_CSI_COMPONENT_H
+#define ESP32_CSI_CSI_COMPONENT_H
+
+#include "time_component.h"
+#include "math.h"
+#include <sstream>
+#include <iostream>
+
+char *project_type;
+
+#define CSI_RAW 1
+#define CSI_AMPLITUDE 0
+#define CSI_PHASE 0
+
+#define CSI_TYPE CSI_RAW
+
+SemaphoreHandle_t mutex = xSemaphoreCreateMutex();
+
+void _wifi_csi_cb(void *ctx, wifi_csi_info_t *data) {
+    xSemaphoreTake(mutex, portMAX_DELAY);
+    std::stringstream ss;
+
+    wifi_csi_info_t d = data[0];
+    char mac[20] = {0};
+    sprintf(mac, "%02X:%02X:%02X:%02X:%02X:%02X", d.mac[0], d.mac[1], d.mac[2], d.mac[3], d.mac[4], d.mac[5]);
+
+    ss << "CSI_DATA,"
+       << project_type << ","
+       << mac << ","
+       // https://github.com/espressif/esp-idf/blob/9d0ca60398481a44861542638cfdc1949bb6f312/components/esp_wifi/include/esp_wifi_types.h#L314
+       << d.rx_ctrl.rssi << ","
+       << d.rx_ctrl.rate << ","
+       << d.rx_ctrl.sig_mode << ","
+       << d.rx_ctrl.mcs << ","
+       << d.rx_ctrl.cwb << ","
+       << d.rx_ctrl.smoothing << ","
+       << d.rx_ctrl.not_sounding << ","
+       << d.rx_ctrl.aggregation << ","
+       << d.rx_ctrl.stbc << ","
+       << d.rx_ctrl.fec_coding << ","
+       << d.rx_ctrl.sgi << ","
+       << d.rx_ctrl.noise_floor << ","
+       << d.rx_ctrl.ampdu_cnt << ","
+       << d.rx_ctrl.channel << ","
+       << d.rx_ctrl.secondary_channel << ","
+       << d.rx_ctrl.timestamp << ","
+       << d.rx_ctrl.ant << ","
+       << d.rx_ctrl.sig_len << ","
+       << d.rx_ctrl.rx_state << ","
+       << real_time_set << ","
+       << get_steady_clock_timestamp() << ","
+       << data->len << ",[";
+
+#if CONFIG_SHOULD_COLLECT_ONLY_LLTF
+    int data_len = 128;
+#else
+    int data_len = data->len;
+#endif
+
+int8_t *my_ptr;
+#if CSI_RAW
+    my_ptr = data->buf;
+    for (int i = 0; i < data_len; i++) {
+        ss << (int) my_ptr[i] << " ";
+    }
+#endif
+#if CSI_AMPLITUDE
+    my_ptr = data->buf;
+    for (int i = 0; i < data_len / 2; i++) {
+        ss << (int) sqrt(pow(my_ptr[i * 2], 2) + pow(my_ptr[(i * 2) + 1], 2)) << " ";
+    }
+#endif
+#if CSI_PHASE
+    my_ptr = data->buf;
+    for (int i = 0; i < data_len / 2; i++) {
+        ss << (int) atan2(my_ptr[i*2], my_ptr[(i*2)+1]) << " ";
+    }
+#endif
+    ss << "]\n";
+
+    printf(ss.str().c_str());
+    fflush(stdout);
+    vTaskDelay(0);
+    xSemaphoreGive(mutex);
+}
+
+void _print_csi_csv_header() {
+    char *header_str = (char *) "type,role,mac,rssi,rate,sig_mode,mcs,bandwidth,smoothing,not_sounding,aggregation,stbc,fec_coding,sgi,noise_floor,ampdu_cnt,channel,secondary_channel,local_timestamp,ant,sig_len,rx_state,real_time_set,real_timestamp,len,CSI_DATA\n";
+    outprintf(header_str);
+}
+
+void csi_init(char *type) {
+    project_type = type;
+
+#ifdef CONFIG_SHOULD_COLLECT_CSI
+    ESP_ERROR_CHECK(esp_wifi_set_csi(1));
+
+    // @See: https://github.com/espressif/esp-idf/blob/master/components/esp_wifi/include/esp_wifi_types.h#L401
+    wifi_csi_config_t configuration_csi;
+    configuration_csi.lltf_en = 1;
+    configuration_csi.htltf_en = 1;
+    configuration_csi.stbc_htltf2_en = 1;
+    configuration_csi.ltf_merge_en = 1;
+    configuration_csi.channel_filter_en = 0;
+    configuration_csi.manu_scale = 0;
+
+    ESP_ERROR_CHECK(esp_wifi_set_csi_config(&configuration_csi));
+    ESP_ERROR_CHECK(esp_wifi_set_csi_rx_cb(&_wifi_csi_cb, NULL));
+
+    _print_csi_csv_header();
+#endif
+}
+
+#endif //ESP32_CSI_CSI_COMPONENT_H

--- a/_components/input_component.h
+++ b/_components/input_component.h
@@ -1,0 +1,43 @@
+#ifndef ESP32_CSI_INPUT_COMPONENT_H
+#define ESP32_CSI_INPUT_COMPONENT_H
+
+#include "csi_component.h"
+
+char input_buffer[256];
+int input_buffer_pointer = 0;
+
+void _handle_input() {
+    if (match_set_timestamp_template(input_buffer)) {
+        printf("Setting local time to %s\n", input_buffer);
+        time_set(input_buffer);
+    } else {
+        printf("Unable to handle input %s\n", input_buffer);
+    }
+}
+
+void input_check() {
+    uint8_t ch = fgetc(stdin);
+
+    while (ch != 0xFF) {
+        if (ch == '\n') {
+            _handle_input();
+            input_buffer[0] = '\0';
+            input_buffer_pointer = 0;
+        } else {
+            input_buffer[input_buffer_pointer] = ch;
+            input_buffer[input_buffer_pointer + 1] = '\0';
+            input_buffer_pointer++;
+        }
+
+        ch = fgetc(stdin);
+    }
+}
+
+void input_loop() {
+    while (true) {
+        input_check();
+        vTaskDelay(10 / portTICK_PERIOD_MS);
+    }
+}
+
+#endif //ESP32_CSI_INPUT_COMPONENT_H

--- a/_components/nvs_component.h
+++ b/_components/nvs_component.h
@@ -1,0 +1,16 @@
+#ifndef ESP32_CSI_NVS_COMPONENT_H
+#define ESP32_CSI_NVS_COMPONENT_H
+
+#include "nvs_flash.h"
+
+void nvs_init() {
+    //Initialize NVS
+    esp_err_t ret = nvs_flash_init();
+    if (ret == ESP_ERR_NVS_NO_FREE_PAGES || ret == ESP_ERR_NVS_NEW_VERSION_FOUND) {
+        ESP_ERROR_CHECK(nvs_flash_erase());
+        ret = nvs_flash_init();
+    }
+    ESP_ERROR_CHECK(ret);
+}
+
+#endif //ESP32_CSI_NVS_COMPONENT_H

--- a/_components/sd_component.h
+++ b/_components/sd_component.h
@@ -1,0 +1,107 @@
+#ifndef ESP32_CSI_SD_COMPONENT_H
+#define ESP32_CSI_SD_COMPONENT_H
+
+#include <stdio.h>
+#include <string.h>
+#include <sys/unistd.h>
+#include <sys/stat.h>
+#include "esp_err.h"
+#include "esp_log.h"
+#include "esp_vfs_fat.h"
+#include "driver/sdmmc_host.h"
+#include "driver/sdspi_host.h"
+#include "sdmmc_cmd.h"
+
+#define PIN_NUM_MISO 2
+#define PIN_NUM_MOSI 15
+#define PIN_NUM_CLK  14
+#define PIN_NUM_CS   13
+
+FILE *f;
+char filename[24] = {0};
+
+void _sd_pick_next_file() {
+    int i = -1;
+    struct stat st;
+    while (true) {
+        i++;
+        printf("Checking %i.csv\n", i);
+        sprintf(filename, "/sdcard/%i.csv", i);
+
+        if (stat(filename, &st) != 0) {
+            break;
+        }
+
+        printf("File size: %li\n", st.st_size);
+    }
+}
+
+void sd_init() {
+#ifdef CONFIG_SEND_CSI_TO_SD
+    sdmmc_host_t host = SDSPI_HOST_DEFAULT();
+    sdspi_slot_config_t slot_config = SDSPI_SLOT_CONFIG_DEFAULT();
+    slot_config.gpio_miso = (gpio_num_t) PIN_NUM_MISO;
+    slot_config.gpio_mosi = (gpio_num_t) PIN_NUM_MOSI;
+    slot_config.gpio_sck = (gpio_num_t) PIN_NUM_CLK;
+    slot_config.gpio_cs = (gpio_num_t) PIN_NUM_CS;
+
+    esp_vfs_fat_sdmmc_mount_config_t mount_config = {
+            .format_if_mount_failed = false,
+            .max_files = 1,
+            .allocation_unit_size = 16 * 1024
+    };
+
+    sdmmc_card_t *card;
+    esp_err_t ret = esp_vfs_fat_sdmmc_mount("/sdcard", &host, &slot_config, &mount_config, &card);
+
+    if (ret != ESP_OK) {
+        if (ret == ESP_FAIL) {
+            ESP_LOGE("sd.h",
+                     "Failed to mount filesystem. "
+                     "  If you want the card to be formatted, set format_if_mount_failed = true."
+            );
+        } else {
+            ESP_LOGE("sd.h",
+                     "Failed to initialize the card (%s). "
+                     "  If you do not have an SD card attached, please ignore this message."
+                     "  Make sure SD card lines have pull-up resistors in place.", esp_err_to_name(ret));
+        }
+        return;
+    } else {
+        sdmmc_card_print_info(stdout, card);
+
+        _sd_pick_next_file();
+        f = fopen(filename, "a");
+    }
+#endif
+}
+
+/*
+ * Printf for both serial AND sd card (if available and configured)
+ */
+void outprintf(const char *format, ...) {
+    va_list args;
+    va_start(args, format);
+
+#ifdef CONFIG_SEND_CSI_TO_SERIAL
+    vprintf(format, args);
+#endif
+
+#ifdef CONFIG_SEND_CSI_TO_SD
+    if (f != NULL) {
+        vfprintf(f, format, args);
+    }
+#endif
+
+    va_end(args);
+}
+
+void sd_flush() {
+#ifdef CONFIG_SEND_CSI_TO_SD
+    fflush(f);
+    fclose(f);
+    f = fopen(filename, "a");
+#endif
+}
+
+#endif //ESP32_CSI_SD_COMPONENT_H

--- a/_components/sockets_component.h
+++ b/_components/sockets_component.h
@@ -1,0 +1,73 @@
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <signal.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include "freertos/event_groups.h"
+#include "freertos/task.h"
+#include "esp_system.h"
+#include "esp_wifi.h"
+#include <esp_http_server.h>
+
+char *data = (char *) "1\n";
+
+void socket_transmitter_sta_loop(bool (*is_wifi_connected)()) {
+    int socket_fd = -1;
+    while (1) {
+        close(socket_fd);
+        char *ip = (char *) "192.168.4.1";
+        struct sockaddr_in caddr;
+        caddr.sin_family = AF_INET;
+        caddr.sin_port = htons(2223);
+        while (!is_wifi_connected()) {
+            // wait until connected to AP
+            printf("wifi not connected. waiting...\n");
+            vTaskDelay(1000 / portTICK_PERIOD_MS);
+        }
+        printf("initial wifi connection established.\n");
+        if (inet_aton(ip, &caddr.sin_addr) == 0) {
+            printf("ERROR: inet_aton\n");
+            continue;
+        }
+
+        socket_fd = socket(PF_INET, SOCK_DGRAM, 0);
+        if (socket_fd == -1) {
+            printf("ERROR: Socket creation error [%s]\n", strerror(errno));
+            continue;
+        }
+        if (connect(socket_fd, (const struct sockaddr *) &caddr, sizeof(struct sockaddr)) == -1) {
+            printf("ERROR: socket connection error [%s]\n", strerror(errno));
+            continue;
+        }
+
+        printf("sending frames.\n");
+        double lag = 0.0;
+        while (1) {
+            double start_time = get_steady_clock_timestamp();
+            if (!is_wifi_connected()) {
+                printf("ERROR: wifi is not connected\n");
+                break;
+            }
+
+            if (sendto(socket_fd, &data, strlen(data), 0, (const struct sockaddr *) &caddr, sizeof(caddr)) !=
+                strlen(data)) {
+                vTaskDelay(1);
+                continue;
+            }
+
+#if defined CONFIG_PACKET_RATE && (CONFIG_PACKET_RATE > 0)
+            double wait_duration = (1000.0 / CONFIG_PACKET_RATE) - lag;
+            int w = floor(wait_duration);
+            vTaskDelay(w);
+#else
+            vTaskDelay(10); // This limits TX to approximately 100 per second.
+#endif
+            double end_time = get_steady_clock_timestamp();
+            lag = end_time - start_time;
+        }
+    }
+}

--- a/_components/time_component.h
+++ b/_components/time_component.h
@@ -1,0 +1,43 @@
+#ifndef ESP32_CSI_TIME_COMPONENT_H
+#define ESP32_CSI_TIME_COMPONENT_H
+
+#include <chrono>
+
+static char *SET_TIMESTAMP_SIMPLE_TEMPLATE = (char *) "%li.%li";
+static char *SET_TIMESTAMP_TEMPLATE = (char *) "SETTIME: %li.%li";
+
+bool real_time_set = false;
+
+bool match_set_timestamp_template(char *candidate_string) {
+    long int tv_sec;
+    long int tv_usec;
+    return sscanf(candidate_string, SET_TIMESTAMP_TEMPLATE, &tv_sec, &tv_usec) > 0;
+}
+
+void time_set(char *timestamp_string) {
+    long int tv_sec;
+    long int tv_usec;
+
+    int res = sscanf(timestamp_string, SET_TIMESTAMP_TEMPLATE, &tv_sec, &tv_usec);
+    if (res <= 0) {
+        res = sscanf(timestamp_string, SET_TIMESTAMP_SIMPLE_TEMPLATE, &tv_sec, &tv_usec);
+    }
+
+    if (res > 0) {
+        struct timeval now = {.tv_sec = tv_sec, .tv_usec = tv_usec};
+        settimeofday(&now, NULL);
+        real_time_set = true;
+    }
+}
+
+double get_system_clock_timestamp() {
+    // returns timestamp in seconds (with decimal places)
+    return std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch()).count() / 1000000.0;
+}
+
+double get_steady_clock_timestamp() {
+    // returns timestamp in seconds (with decimal places)
+    return std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now().time_since_epoch()).count() / 1000000.0;
+}
+
+#endif //ESP32_CSI_TIME_COMPONENT_H

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,3 +1,4 @@
 idf_component_register(
-        SRCS main.cc
-        INCLUDE_DIRS "")
+    SRCS main.cc
+    INCLUDE_DIRS "../_components"
+)

--- a/main/component.mk
+++ b/main/component.mk
@@ -2,4 +2,4 @@
 # "main" pseudo-component makefile.
 #
 # (Uses default behaviour of compiling all source files in directory, adding 'include' to include path.)
-COMPONENT_ADD_INCLUDEDIRS += ../../_components
+COMPONENT_ADD_INCLUDEDIRS += ../_components

--- a/main/main.cc
+++ b/main/main.cc
@@ -10,11 +10,11 @@
 #include "esp_log.h"
 #include "nvs_flash.h"
 
-#include "../../_components/nvs_component.h"
-#include "../../_components/sd_component.h"
-#include "../../_components/csi_component.h"
-#include "../../_components/time_component.h"
-#include "../../_components/input_component.h"
+#include "../_components/nvs_component.h"
+#include "../_components/sd_component.h"
+#include "../_components/csi_component.h"
+#include "../_components/time_component.h"
+#include "../_components/input_component.h"
 
 #ifdef CONFIG_WIFI_CHANNEL
 #define WIFI_CHANNEL CONFIG_WIFI_CHANNEL


### PR DESCRIPTION
## Summary
- bring in `_components` headers from ESP32-CSI-Tool
- fix include paths so the build can find these headers
- document how to fetch/update the CSI Tool components

## Testing
- `python -m py_compile collect_csi.py`

------
https://chatgpt.com/codex/tasks/task_e_684173260884832bba388195393ea61a