### PR TITLE
Fix missing headers

### DIFF
--- a/_components/csi_component.h
+++ b/_components/csi_component.h
@@ -5,6 +5,7 @@
 #include "math.h"
 #include <sstream>
 #include <iostream>
+#include <freertos/semphr.h>
 
 char *project_type;
 

--- a/_components/time_component.h
+++ b/_components/time_component.h
@@ -2,6 +2,7 @@
 #define ESP32_CSI_TIME_COMPONENT_H
 
 #include <chrono>
+#include <sys/time.h>
 
 static char *SET_TIMESTAMP_SIMPLE_TEMPLATE = (char *) "%li.%li";
 static char *SET_TIMESTAMP_TEMPLATE = (char *) "SETTIME: %li.%li";


### PR DESCRIPTION
## Summary
- include `<sys/time.h>` so `settimeofday` works
- include `<freertos/semphr.h>` for `SemaphoreHandle_t`

## Testing
- `idf.py --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68418664cc0c832b9ffaa774ad955bff