### PR TITLE
Fix wifi initialization for CSI capture

### DIFF
--- a/main/main.cc
+++ b/main/main.cc
@@ -6,6 +6,7 @@
 #include "freertos/event_groups.h"
 #include "esp_wifi.h"
 #include "esp_event.h"
+#include "esp_netif.h"
 #include "esp_http_server.h"
 #include "esp_log.h"
 #include "nvs_flash.h"
@@ -66,6 +67,8 @@ void config_print() {
 }
 
 void passive_init() {
+    esp_netif_init();
+    esp_event_loop_create_default();
     wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
     ESP_ERROR_CHECK(esp_wifi_init(&cfg));
     ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_NULL));


### PR DESCRIPTION
## Summary
- initialize the ESP netif and event loop before starting WiFi
- include `esp_netif.h`

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846ff9ee184832b8e78b4a275dad03c