### PR TITLE
Add DEVICE_ID build option

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ idf.py -p "$ESPPORT" flash monitor
 
 The default channel is configured through the `WIFI_CHANNEL` value. You can change it either in `main/main.cc` or by modifying the `CONFIG_WIFI_CHANNEL` setting in `sdkconfig`.
 
+## Device ID
+
+Each board should be built with a unique identifier using the `CONFIG_DEVICE_ID` option. Run `idf.py menuconfig` and set a different string for every device so CSI data can be traced back to the correct board.
+
 ## ESP32-CSI-Tool components
 
 This project reuses helper components from the [ESP32-CSI-Tool](https://github.com/StevenMHernandez/ESP32-CSI-Tool) repository. The required header files are included in the `_components` directory. If you need to update or re-fetch these files, clone the CSI tool repository and copy its `_components` folder into the root of this project:

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -6,6 +6,12 @@ menu "ESP32 CSI Tool Config"
         help
             Select the WiFi channel to listen to passively. In North America, valid channels are {1,2,3,...,10,11}.
 
+    config DEVICE_ID
+        string "Device identifier"
+        default "BOARD1"
+        help
+            Unique ID string for this device. Use a different value for each board.
+
     config SHOULD_COLLECT_CSI
         bool "Should this ESP32 collect and print CSI data?"
         default "y"

--- a/main/main.cc
+++ b/main/main.cc
@@ -90,6 +90,6 @@ extern "C" void app_main(void) {
     nvs_init();
     sd_init();
     passive_init();
-    csi_init((char *) "PASSIVE");
+    csi_init((char *)CONFIG_DEVICE_ID);
     input_loop();
 }


### PR DESCRIPTION
## Summary
- add `DEVICE_ID` Kconfig option
- use `CONFIG_DEVICE_ID` when initializing CSI
- document the new option in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68471372afd8832b877b2673aba95b27