### PR TITLE
Fix worker epoch timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,3 +128,19 @@ python3 collect_multi_csi.py --device STA1:/dev/ttyUSB0 --device STA2:/dev/ttyUS
 ```
 
 
+### CSV format v2
+
+CSI lines are written in comma-separated form. Version 2 replaces the
+previous `local_timestamp` and `real_timestamp` fields with a single
+`timestamp` column and adds `phy_timestamp` which exposes the Wi-Fi
+hardware TSF value. The `timestamp` field reports epoch microseconds once
+the system clock is set. Before that, masters use monotonic microseconds
+since boot and workers use the value from `get_synced_time()`.
+
+The `real_time_set` column now flags whether `timestamp` contains epoch
+time (`1`) or a monotonic/synchronized value (`0`). Downstream tools that
+expected the old `real_timestamp` column should switch to `timestamp` and
+may need to update column indices accordingly.
+
+
+

--- a/_components/time_component.h
+++ b/_components/time_component.h
@@ -38,6 +38,18 @@ static inline double get_system_clock_timestamp() {
     return tv.tv_sec + tv.tv_usec / 1000000.0;
 }
 
+static inline uint64_t get_system_time_us() {
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    return (uint64_t)tv.tv_sec * 1000000ULL + tv.tv_usec;
+}
+
+static inline uint64_t get_monotonic_time_us() {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (uint64_t)ts.tv_sec * 1000000ULL + ts.tv_nsec / 1000;
+}
+
 static inline double get_steady_clock_timestamp() {
     struct timespec ts;
     clock_gettime(CLOCK_MONOTONIC, &ts);

--- a/scripts/collect_csi.py
+++ b/scripts/collect_csi.py
@@ -10,8 +10,9 @@ CSV_FILE = '../data/Findings_1.csv'
 HEADERS = [
     "type", "role", "mac", "rssi", "rate", "sig_mode", "mcs", "bandwidth",
     "smoothing", "not_sounding", "aggregation", "stbc", "fec_coding", "sgi",
-    "noise_floor", "ampdu_cnt", "channel", "secondary_channel", "local_timestamp",
-    "ant", "sig_len", "rx_state", "real_time_set", "real_timestamp", "len", "seq_ctrl", "CSI_DATA"
+    "noise_floor", "ampdu_cnt", "channel", "secondary_channel", "timestamp",
+    "phy_timestamp", "ant", "sig_len", "rx_state", "real_time_set", "len",
+    "seq_ctrl", "CSI_DATA"
 ]
 
 try:

--- a/scripts/collect_multiple_csi
+++ b/scripts/collect_multiple_csi
@@ -72,7 +72,15 @@ def main() -> None:
         with open(args.output, "w", newline="", encoding="utf-8") as f:
             writer = csv.writer(f)
             # Write header row (adjust columns based on your CSI format)
-            writer.writerow(["device_id", "timestamp", "mac", "rssi", "rate", "sig_mode", "mcs", "bandwidth", "smoothing", "not_sounding", "aggregation", "stbc", "fec_coding", "sgi", "noise_floor", "ampdu_cnt", "channel", "secondary_channel", "local_timestamp", "ant", "sig_len", "rx_state", "real_time_set", "real_timestamp", "len", "seq_ctrl", "csi_data"])
+            writer.writerow([
+                "device_id",
+                "type", "role", "mac", "rssi", "rate", "sig_mode", "mcs",
+                "bandwidth", "smoothing", "not_sounding", "aggregation",
+                "stbc", "fec_coding", "sgi", "noise_floor", "ampdu_cnt",
+                "channel", "secondary_channel", "timestamp", "phy_timestamp",
+                "ant", "sig_len", "rx_state", "real_time_set", "len",
+                "seq_ctrl", "csi_data"
+            ])
             
             for device_id, port in devices:
                 ser = open_serial(port, args.baud)


### PR DESCRIPTION
## Summary
- add CSV version comment in CSI header and reorder multi-device collector to match firmware
- cast timestamps explicitly, buffer CSI output string
- document new `timestamp` semantics in CSV format v2 section

## Testing
- `python3 -m py_compile scripts/collect_csi.py scripts/collect_multiple_csi`


------
https://chatgpt.com/codex/tasks/task_e_68516b09a75c832b986b674d445600fa