### PR TITLE
Improve CSI pairing using timestamps

### DIFF
--- a/scripts/csi_matcher.py
+++ b/scripts/csi_matcher.py
@@ -5,13 +5,29 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from typing import Dict, Tuple
+from collections import deque
+from typing import Deque, Dict, Tuple
 
 from scripts.csi_parser import CSIPacket
 
 
 class PairMatcher:
-    """Pair CSI packets with the same MAC and sequence number."""
+    """Pair CSI packets with the same MAC and sequence number.
+
+    Parameters
+    ----------
+    queue_in : asyncio.Queue[CSIPacket]
+        Input queue with parsed packets.
+    queue_out : asyncio.Queue[Tuple[CSIPacket, CSIPacket]]
+        Output queue for paired packets.
+    gc_interval : float, optional
+        Interval in seconds between garbage-collection sweeps.
+    timeout : float, optional
+        Seconds after which unpaired packets are dropped.
+    ts_window : int | None, optional
+        Maximum timestamp difference (microseconds) for two packets to be
+        considered a pair. If ``None`` no timestamp filtering is applied.
+    """
 
     def __init__(
         self,
@@ -27,13 +43,24 @@ class PairMatcher:
         self.timeout = timeout
         self.ts_window = ts_window
         self.pending: Dict[
-            Tuple[str, int], Dict[str, list[tuple[CSIPacket, float]]]
+            Tuple[str, int], Dict[str, Deque[tuple[CSIPacket, float]]]
         ] = {}
         self.master_count = 0
         self.worker_count = 0
         self.paired = 0
         self.dropped = 0
         self._gc_task: asyncio.Task | None = None
+
+    @staticmethod
+    def _insert_sorted(
+        dq: Deque[tuple[CSIPacket, float]], pkt: CSIPacket, ts: float
+    ) -> None:
+        """Insert ``pkt`` into ``dq`` keeping it ordered by packet timestamp."""
+        for idx, (other, _) in enumerate(dq):
+            if pkt.timestamp < other.timestamp:
+                dq.insert(idx, (pkt, ts))
+                return
+        dq.append((pkt, ts))
 
     async def _gc(self) -> None:
         try:
@@ -46,7 +73,7 @@ class PairMatcher:
                         pkt_list = v[role]
                         while pkt_list and now - pkt_list[0][1] > self.timeout:
                             logging.warning(f"Pair timeout for {k}")
-                            pkt_list.pop(0)
+                            pkt_list.popleft()
                             self.dropped += 1
                         if not pkt_list:
                             v.pop(role)
@@ -63,8 +90,8 @@ class PairMatcher:
                 key = (pkt.mac, pkt.seq_ctrl)
                 now = time.monotonic()
                 entry = self.pending.setdefault(key, {})
-                pkt_list = entry.setdefault(pkt.receiver_id, [])
-                pkt_list.append((pkt, now))
+                pkt_list = entry.setdefault(pkt.receiver_id, deque())
+                self._insert_sorted(pkt_list, pkt, now)
                 if pkt.receiver_id == "master":
                     self.master_count += 1
                 else:
@@ -76,17 +103,12 @@ class PairMatcher:
                         m_pkt, _ = masters[0]
                         w_pkt, _ = workers[0]
                         diff = abs(m_pkt.timestamp - w_pkt.timestamp)
-                        if self.ts_window is None or diff <= self.ts_window:
-                            masters.pop(0)
-                            workers.pop(0)
-                            self.paired += 1
-                            await self.queue_out.put((m_pkt, w_pkt))
-                        else:
-                            if m_pkt.timestamp < w_pkt.timestamp:
-                                masters.pop(0)
-                            else:
-                                workers.pop(0)
-                            self.dropped += 1
+                        if self.ts_window is not None and diff > self.ts_window:
+                            break
+                        masters.popleft()
+                        workers.popleft()
+                        self.paired += 1
+                        await self.queue_out.put((m_pkt, w_pkt))
                     if not masters and not workers:
                         self.pending.pop(key, None)
         except asyncio.CancelledError:

--- a/scripts/csi_pipeline.py
+++ b/scripts/csi_pipeline.py
@@ -35,6 +35,7 @@ class Settings:
     antenna_distance_m: float = 0.06
     gc_interval: float = 0.01
     match_timeout: float = 1.0
+    match_ts_window_us: Optional[int] = None
     flush_bytes: int = 8192
     calibration: Optional[str] = None
     stats: bool = False
@@ -61,6 +62,7 @@ def env_or_cli(args: argparse.Namespace) -> Settings:
         "baud": args.baud,
         "output": args.output,
         "calibration": args.calibration,
+        "match_ts_window_us": args.ts_window_us,
         "stats": args.stats,
     }
     for k, v in cli_map.items():
@@ -79,6 +81,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--baud", type=int)
     parser.add_argument("--output")
     parser.add_argument("--calibration")
+    parser.add_argument("--ts-window-us", type=int, dest="ts_window_us")
     parser.add_argument("--stats", action="store_true")
     return parser.parse_args()
 
@@ -110,6 +113,7 @@ async def main_async(opts: Settings) -> None:
         pair_queue,
         gc_interval=opts.gc_interval,
         timeout=opts.match_timeout,
+        ts_window=opts.match_ts_window_us,
     )
     cal_vector = load_calibration(opts.calibration)
     estimator = AoAEstimator(

--- a/tests/test_matcher_multi.py
+++ b/tests/test_matcher_multi.py
@@ -1,0 +1,35 @@
+import asyncio
+
+import pytest
+
+from scripts.csi_matcher import PairMatcher
+from scripts.csi_parser import CSIPacket
+
+
+@pytest.mark.asyncio
+async def test_multi_pair_sorted():
+    in_q = asyncio.Queue()
+    out_q = asyncio.Queue()
+    matcher = PairMatcher(in_q, out_q, ts_window=10)
+    task = asyncio.create_task(matcher.run())
+
+    masters = [CSIPacket("aa", 1, t, -30, 1, [], "", "master") for t in (0, 10, 20)]
+    workers = [CSIPacket("aa", 1, t, -30, 1, [], "", "worker") for t in (1, 11, 21)]
+
+    # feed masters then workers in reverse order
+    for pkt in masters:
+        await in_q.put(pkt)
+    for pkt in reversed(workers):
+        await in_q.put(pkt)
+
+    for _ in range(10):
+        if out_q.qsize() >= 3:
+            break
+        await asyncio.sleep(0.01)
+    task.cancel()
+    await asyncio.gather(task, return_exceptions=True)
+
+    results = [out_q.get_nowait() for _ in range(3)]
+    ts_order = [m.timestamp for m, _ in results]
+    assert ts_order == [0, 10, 20]
+    assert matcher.dropped == 0


### PR DESCRIPTION
## Summary
- improve PairMatcher to handle multiple packets with same MAC and seq by storing
  per-receiver queues
- use an optional timestamp window to select the closest packets
- update garbage collection logic accordingly

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863a1841e44832bb4cffca24327c79d