### PR TITLE
Add RSSI output to pipeline

### DIFF
--- a/scripts/csi_estimator.py
+++ b/scripts/csi_estimator.py
@@ -39,7 +39,7 @@ class AoAEstimator:
     def __init__(
         self,
         queue_in: asyncio.Queue[Tuple[CSIPacket, CSIPacket]],
-        queue_out: asyncio.Queue[Tuple[int, str, int, float, str, str]],
+        queue_out: asyncio.Queue[Tuple[int, str, int, float, int, int, str, str]],
         antenna_dist: float = 0.06,
         cal_vector: Optional[np.ndarray] = None,
     ):
@@ -78,6 +78,8 @@ class AoAEstimator:
                         master_pkt.mac,
                         master_pkt.seq_ctrl,
                         aoa,
+                        master_pkt.rssi,
+                        worker_pkt.rssi,
                         master_pkt.csi_raw,
                         worker_pkt.csi_raw,
                     )

--- a/tests/test_e2e_async.py
+++ b/tests/test_e2e_async.py
@@ -38,9 +38,20 @@ async def test_e2e_pipeline():
         t.cancel()
     await asyncio.gather(*tasks, return_exceptions=True)
 
-    ts, mac, seq, aoa, iq_m, iq_w = await asyncio.wait_for(result_q.get(), timeout=1)
+    (
+        ts,
+        mac,
+        seq,
+        aoa,
+        master_rssi,
+        worker_rssi,
+        iq_m,
+        iq_w,
+    ) = await asyncio.wait_for(result_q.get(), timeout=1)
     assert mac == "aa"
     assert seq == 1
     assert aoa == pytest.approx(31, abs=1)
+    assert master_rssi == -30
+    assert worker_rssi == -30
     assert iq_m == "1 0"
     assert iq_w == "0 1"


### PR DESCRIPTION
## Summary
- propagate RSSI values through AoA estimator results
- log master and worker RSSI in CSV output
- update e2e test for new tuple format

## Testing
- `pip install -r dev-requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863d688b4b8832ba9d48bd9c08ff74c